### PR TITLE
Fix blocking callback bug

### DIFF
--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -630,7 +630,8 @@ def skip_input_signal_add_output_signal(num_outputs, out_flex_key, in_flex_key, 
                 context_value.set(ctx)
             try:
                 outputs = f(*args, **kwargs)
-            except Exception as e:
+            except Exception:
+                logging.exception(f"Exception raised in blocking callback [{f.__name__}]")
                 outputs = no_update if single_output else [no_update] * num_outputs       
             
             return _append_output(outputs, datetime.utcnow().timestamp(), single_output, out_flex_key)

--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -602,7 +602,7 @@ class BlockingCallbackTransform(StatefulDashTransform):
                 State(start_blocked_id, "data")
             )
             # Modify the original callback to send finished signal.
-            single_output = len(callback.outputs) <= 1
+            num_outputs = len(callback.outputs)
             out_flex_key = callback.outputs.append(Output(end_server_id, "data"))
             # Change original inputs to state.
             for i, item in enumerate(callback.inputs):
@@ -612,22 +612,27 @@ class BlockingCallbackTransform(StatefulDashTransform):
             st_flex_key = callback.inputs.append(State(start_client_ctx, "data"))
             # Modify the callback function accordingly.
             f = callback.f
-            callback.f = skip_input_signal_add_output_signal(single_output, out_flex_key, in_flex_key, st_flex_key)(f)
+            callback.f = skip_input_signal_add_output_signal(num_outputs, out_flex_key, in_flex_key, st_flex_key)(f)
 
         return callbacks
 
 
-def skip_input_signal_add_output_signal(single_output, out_flex_key, in_flex_key, st_flex_key):
+def skip_input_signal_add_output_signal(num_outputs, out_flex_key, in_flex_key, st_flex_key):
     def wrapper(f):
         @functools.wraps(f)
         def decorated_function(*args, **kwargs):
             args, kwargs, fltr = _skip_inputs(args, kwargs, [in_flex_key, st_flex_key])
             cached_ctx = fltr[1]
+            single_output = num_outputs <= 1
             if cached_ctx is not None and "triggered" in cached_ctx:
                 ctx = context_value.get()
                 ctx["triggered_inputs"] = cached_ctx["triggered"]
                 context_value.set(ctx)
-            outputs = f(*args, **kwargs)
+            try:
+                outputs = f(*args, **kwargs)
+            except Exception as e:
+                outputs = no_update if single_output else [no_update] * num_outputs       
+            
             return _append_output(outputs, datetime.utcnow().timestamp(), single_output, out_flex_key)
 
         return decorated_function


### PR DESCRIPTION
## Changes summary
- Add try, except block around calling of function in blocking callback transform
- If callback fails due to an exception, return no_update in all outputs, but still return current timestamp to `end_server_id` component. 

## Reason for changes
- Current code has a bug. If a blocking callback fails due to an exception being thrown, the callback will never be triggered again
-  This is due to the `end_server_id` never being updated upon failure of the callback. In further calls of the callback, the clientside callback that ensures the `blocking` behaviour still thinks the previous callback is being ran. This is only released after `blocking_timeout`

## Testing
- The behaviour can be reproduced with the example given. 
- By applying these changes the callback is unblocked

```python
from dash_extensions.enrich import Dash, dcc, html, Input, Output, callback


app = Dash(__name__)

app.layout = html.Div([
    html.Div([
        "Input: ",
        dcc.Input(id='my-input', value='initial value', type='text')
    ]),
    html.P(id='my-output')
])


i = 0

@callback(
    Output('my-output', 'children'),
    Input('my-input', 'value'),
    prevent_initial_call=True,
    blocking=True,
)
def check_input(input_value):
    global i
    i += 1
    if input_value == "bad":
        raise Exception(f'input is bad! {i}')
    return i


if __name__ == '__main__':
    app.run(debug=False)
``` 





