### PR TITLE
Trigger for clientside callbacks

### DIFF
--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -11,6 +11,8 @@ import struct
 import sys
 import threading
 import uuid
+from itertools import compress
+
 import plotly
 import dash
 
@@ -952,8 +954,6 @@ class Trigger(Input):
 
 class TriggerTransform(DashTransform):
 
-    # NOTE: This transform cannot be implemented for clientside callbacks since the JS can't be modified from here.
-
     def apply_serverside(self, callbacks):
         for callback in callbacks:
             is_trigger = [isinstance(item, Trigger) for item in callback.inputs]
@@ -963,6 +963,24 @@ class TriggerTransform(DashTransform):
             # If so, filter the callback args.
             f = callback.f
             callback.f = filter_args(is_trigger)(f)
+        return callbacks
+
+    def apply_clientside(self, callbacks):
+        for callback in callbacks:
+            is_not_trigger = [not isinstance(item, Trigger) for item in callback.inputs]
+            # Check if any triggers are there.
+            if all(is_not_trigger):
+                continue
+            # If so, filter the callback args.
+            args = [f"arg{i}" for i in range(len(callback.inputs))]
+            filtered_args = compress(args, is_not_trigger)
+            if isinstance(callback.f, ClientsideFunction):
+                callback.f = f"window.dash_clientside['{callback.f.namespace}']['{callback.f.function_name}']"
+            callback.f = f"""
+function({", ".join(args)}) {{
+const func = {callback.f};
+return func({", ".join(filtered_args)});
+}}"""
         return callbacks
 
 

--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -11,8 +11,6 @@ import struct
 import sys
 import threading
 import uuid
-from itertools import compress
-
 import plotly
 import dash
 
@@ -47,6 +45,7 @@ from dash.dependencies import _Wildcard, DashDependency  # lgtm [py/unused-impor
 from dash.development.base_component import Component
 from flask import session
 from flask_caching.backends import FileSystemCache, RedisCache
+from itertools import compress
 from more_itertools import flatten
 from collections import defaultdict
 from typing import Dict, Callable, List, Union, Any, Tuple, Optional, Generic, TypeVar


### PR DESCRIPTION
From TriggerTransform:
> NOTE: This transform cannot be implemented for clientside callbacks since the JS can't be modified from here.

I respectfully beg to differ.

We can wrap the callback JS function in another function which takes out the trigger args.

Roughly like this:

```javascript
// original callback:
function(important, _irrelevant, interesting) {
    return important * interesting;
}


// wrapped callback:
function(important, _irrelevant, interesting) {
    const func = function(important, interesting) {  // <-- '_irrelevent' removed
        return important * interesting;
    };
    return func(important, interesting);
}
```

Implementation is in this PR. 
