### PR TITLE
Enhance `DashBlueprint.register()` to accept custom PrefixIdTransform instances in `prefix` param

### DIFF
--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -307,13 +307,19 @@ class DashBlueprint:
         return callbacks, clientside_callbacks
 
     # TODO: Include or not? The plugin still seems a bit immature.
-    def register(self, app: Union[dash.Dash, DashProxy], module, prefix=None, **kwargs):
-        if prefix is not None:
+    def register(self, app: Union[dash.Dash, DashProxy], module, prefix: Union[str, PrefixIdTransform, None]=None, **kwargs):      
+        # Deal with the prefix -> # prefix can be a string but now also custom PrefixIdTransform instance
+        if isinstance(prefix, str) and prefix:                                                  
+            # Create a PrefixIdTransform if prefix is a non-empty string and append it to transforms.
             prefix_transform = PrefixIdTransform(prefix)
             self.transforms.append(prefix_transform)
+        elif prefix is not None:                                                        
+            # Register the prefix as an instance of PrefixIdTransform or similar.      
+            self.transforms.append(prefix)                                            
+        # Register the callbacks and page.
         self.register_callbacks(app)
         dash.register_page(module, layout=self._layout_value, **kwargs)
-
+    
     def clear(self):
         self.callbacks = []
         self.clientside_callbacks = []


### PR DESCRIPTION
**Context:**
Before this commit, the `prefix` parameter of `DashBlueprint.register()` could only accept a string, which would then be used to create and register a default `PrefixIdTransform` instance in the `transforms` list of the blueprint. This behavior restricted the flexibility as it only utilized the standard `PrefixIdTransform` with no possibility to specify a custom escape function.

**Problem:**
While `PrefixIdTransform` itself does offer the option to specify a custom escape function, this option is lost when using the `prefix` parameter of `DashBlueprint.register()`, as it defaults to using the standard `PrefixIdTransform`. In many use cases, such as mine, there is a need to skip the prefix modification for specific elements, which was not feasible without implementing a cumbersome workaround. This limitation was due to the inability to use a custom escape function within the `PrefixIdTransform` created by `register()`.

**Solution:**
This commit enhances the functionality of `DashBlueprint.register()` by allowing the `prefix` parameter to accept either a string or a custom `PrefixIdTransform` instance. This change introduces the following improvements:

- **Customizability:** Developers can now pass a custom `PrefixIdTransform` instance with their own logic for the escape function, allowing for greater control over which components are affected by the prefixing.

- **Flexibility:** By enabling the direct use of a customized `PrefixIdTransform`, developers retain the option to specify how and when to apply the escape logic.

- **Reduced Complexity:** It eliminates the need for complex workarounds previously required to handle special cases where prefixing should be selectively applied.

- **Clarity and Maintainability:** The prefix machinery more maintainable by directly supporting different configurations of `PrefixIdTransform`.

**Impact:**
This change will significantly enhance the flexibility and usability of `DashBlueprint.register()` for developers needing more control over component ID transformations. It aligns with the principles of extensibility and customization. Additionally, it ensures that the powerful features of `PrefixIdTransform`, such as custom escape functions, are fully usable in all scenarios, supporting complex application architectures more effectively.