### PR TITLE
Use dmc.NotificationProvider only if dmc version is >= 0.14.0

### DIFF
--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -721,7 +721,8 @@ def setup_notifications_log_config():
         layout.append(html.Div(id=log_id))
         if dmc.__version__ < "0.14.0":
             layout.append(dmc.NotificationsProvider())
-        layout.append(dmc.NotificationProvider(zIndex=2000))
+        else:
+            layout.append(dmc.NotificationProvider(zIndex=2000))
 
         return layout
 


### PR DESCRIPTION
`NotificationProvider` is not available before. 