### PR TITLE
Bump mermaid from 9.2.2 to 11.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "dash-extensions-js": "0.0.2",
         "dompurify": "^2.3.6",
         "loader-utils": ">=3.2.1",
-        "mermaid": "^9.2.2",
+        "mermaid": "^11.4.1",
         "node-polyfill-webpack-plugin": "^2.0.1",
         "ramda": "^0.26.1",
         "react-loadable": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dash-extensions-js": "0.0.2",
     "dompurify": "^2.3.6",
     "loader-utils": ">=3.2.1",
-    "mermaid": "^9.2.2",
+    "mermaid": "^11.4.1",
     "node-polyfill-webpack-plugin": "^2.0.1",
     "ramda": "^0.26.1",
     "react-loadable": "^5.5.0",


### PR DESCRIPTION
# Summary of Changes
Updated the mermaid version, based on https://github.com/laurent22/joplin/issues/8728, to access new chart types. 

# Reason for Changes
See issue: [No diagram type detected for text "quadrantChart..."](https://github.com/emilhe/dash-extensions/issues/362)

# Testing
I've run into some build issues, so haven't been able to test.

One test could be:
```
from dash import Dash, Input, Output, html

from dash_extensions import Mermaid

chart = """
quadrantChart
    title Reach and engagement of campaigns
    x-axis Low Reach --> High Reach
    y-axis Low Engagement --> High Engagement
    quadrant-1 We should expand
    quadrant-2 Need to promote
    quadrant-3 Re-evaluate
    quadrant-4 May be improved
    Campaign A: [0.3, 0.6]
    Campaign B: [0.45, 0.23]
    Campaign C: [0.57, 0.69]
    Campaign D: [0.78, 0.34]
    Campaign E: [0.40, 0.34]
    Campaign F: [0.35, 0.78]
"""
app = Dash()
app.layout = html.Div([Mermaid(id="mermaid"), html.Button("Click me", id="trigger")])


@app.callback(Output("mermaid", "chart"), Input("trigger", "n_clicks"), prevent_initial_call=True)
def set_chart(_):
    return chart


if __name__ == "__main__":
    app.run_server(port=9998)
```