### PR TITLE
Resolve warnings related to datetime library

### DIFF
--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -12,7 +12,7 @@ import sys
 import threading
 import uuid
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import compress
 from types import UnionType
 from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, TypeVar, Union, get_args
@@ -690,7 +690,7 @@ def skip_input_signal_add_output_signal(num_outputs, out_flex_key, in_flex_key, 
                     logging.exception(f"Exception raised in blocking callback [{f.__name__}]")
                 outputs = _determine_outputs(single_output)
 
-            return _append_output(outputs, datetime.utcnow().timestamp(), single_output, out_flex_key)
+            return _append_output(outputs, datetime.now(timezone.utc).timestamp(), single_output, out_flex_key)
 
         return decorated_function
 


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warnings coming from the `datetime` library which you can find in the [CI logs](https://github.com/emilhe/dash-extensions/actions/runs/14595525289/job/40940373221#step:9:102):
```python
/home/runner/work/dash-extensions/dash-extensions/dash_extensions/enrich.py:693: DeprecationWarning:
datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```